### PR TITLE
Update firebase.js

### DIFF
--- a/src/firebase.js
+++ b/src/firebase.js
@@ -1,4 +1,4 @@
-import * as firebase from 'firebase/app'
+import firebase from 'firebase/app'
 import 'firebase/auth'
 import 'firebase/firestore'
 


### PR DESCRIPTION
In version 8.0.0, the Firebase SDK had a breaking change in the way it handles exports:

Breaking change: browser fields in package.json files now point to ESM bundles instead of CJS bundles. Users who are using ESM imports must now use the default import instead of a namespace import.

Before 8.0.0

import * as firebase from 'firebase/app'
After 8.0.0

import firebase from 'firebase/app'
Code that uses require('firebase/app') or require('firebase') will still work, but in order to get proper typings (for code completion, for example) users should change these require calls to require('firebase/app').default or require('firebase').default. This is because the SDK now uses typings for the ESM bundle, and the different bundles share one typings file.

So, you will have to use the new ESM bundle default export:

import firebase from "firebase/app"
firebase.initializeApp({ ... })

Source: https://stackoverflow.com/questions/64545862/upgrade-to-firebase-js-8-0-0-attempted-import-error-app-is-not-exported-from